### PR TITLE
Fixed file access error and updated version number.

### DIFF
--- a/LESs/MainWindow.xaml.cs
+++ b/LESs/MainWindow.xaml.cs
@@ -18,7 +18,7 @@ namespace LESs
     /// </summary>
     public partial class MainWindow : Window
     {
-        const string IntendedVersion = "0.0.1.100";
+        const string IntendedVersion = "0.0.1.101";
 
         private readonly BackgroundWorker worker = new BackgroundWorker();
         private bool WasPatched = true;
@@ -33,8 +33,6 @@ namespace LESs
             LeagueVersionLabel.Content = IntendedVersion;
             if (File.Exists("debug.log"))
                 File.Delete("debug.log");
-
-            File.Create("debug.log");
 
             if (Directory.Exists("temp"))
             {


### PR DESCRIPTION
File.Create() doesn't need to be called to be able to use
File.AppendAllText(). Refer to this image for the file access error that
occurred: http://i.imgur.com/sw1QRiC.png
