### PR TITLE
Implement LESs removing mechanic for Garena

### DIFF
--- a/LESs/MainWindow.xaml.cs
+++ b/LESs/MainWindow.xaml.cs
@@ -332,6 +332,7 @@ namespace LESs
             }
 
             string lolLocation = null;
+            bool overwrite = true;
             Dispatcher.Invoke(DispatcherPriority.Input, new ThreadStart(() =>
             {
                 lolLocation = LocationTextbox.Text;
@@ -347,6 +348,14 @@ namespace LESs
                 {
                     // Store the date in another file. It will be used in LESs removing.
                     File.Copy(versionLocation, Path.Combine(lolRootLocation.LocalPath, "LESs_recent.version"), true);
+                }
+                if(Directory.Exists(Path.Combine(lolLocation, "LESsBackup")))
+                {
+                    MessageBoxResult diagRst = MessageBox.Show("We found that you already have backup files. Overwriting it may result in you losing your original files." + Environment.NewLine + "Would you like to overwrite your old files?", "You already have backup files", MessageBoxButton.YesNo);
+                    if (diagRst == MessageBoxResult.No)
+                    {
+                        overwrite = false;
+                    }
                 }
             }
             Dictionary<string, SwfFile> swfs = new Dictionary<string, SwfFile>();
@@ -375,7 +384,7 @@ namespace LESs
                                 }
                                 if (!File.Exists(Path.Combine(lolLocation, "LESsBackup", INTENDED_VERSION, patch.Swf)))
                                 {
-                                    File.Copy(Path.Combine(lolLocation, patch.Swf), Path.Combine(lolLocation, "LESsBackup", patch.Swf));
+                                    if(overwrite) File.Copy(Path.Combine(lolLocation, patch.Swf), Path.Combine(lolLocation, "LESsBackup", patch.Swf));
                                 }
                             }
                             else


### PR DESCRIPTION
This is a basic LESs removing mechanism for Garena installations.
As Garena does not use Riot launcher. We can't just delete some file and have the launcher do the job.
Instead, we use backup files stored in the user's computer.

Tested on LoL Thai server.
It was able to patch and backup files properly. 
